### PR TITLE
reset cancelObj[response.config.baseURL] to null when response error

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ function request(options) {
       return response;
       
     }, function(error){
+    	cancelObj[response.config.baseURL] = null;
       if (error.response) {
         return Promise.reject(error);
       } else if (error.request) {


### PR DESCRIPTION
Do the reset not only when response success, but also when response error. Otherwise, it will block following requests.